### PR TITLE
Added explicit call to load tidyverse

### DIFF
--- a/_episodes_rmd/03-dplyr-tidyr.Rmd
+++ b/_episodes_rmd/03-dplyr-tidyr.Rmd
@@ -69,6 +69,10 @@ To learn more about **`dplyr`** and **`tidyr`** after the workshop, you may want
 To make sure, everyone will use the same dataset for this lesson, we'll read again the SAFI dataset that we downloaded earlier.
 
 ```{r, results = 'hide', purl = FALSE, message=FALSE}
+
+## load the tidyverse
+library(tidyverse)
+
 interviews <- read_csv("data/SAFI_clean.csv", na = "NULL")
 
 ## inspect the data


### PR DESCRIPTION
When done in a workshop this may not entirely be necessary but I think we must consider learners that revisit the workshops, or work ahead in an asynchronous manner.  They might not always be aware that the libraries need to be loaded.

Including `library(tidyverse)` call at the beginning of the lesson follows the examples run in episodes 2 and 4, and would most likely help those that pick up this lesson online or on their own, reduce frustration and increase exposure to loading libraries.