### PR TITLE
Removed SQLite from packages to be installed

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -12,7 +12,7 @@ using R much easier and more interactive. You need to install R before you
 install RStudio. After installing both programs, you will need to install the
 **`tidyverse`** package from within RStudio. Follow the instructions below for
 your operating system, and then follow the instructions to install
-**`tidyverse`** and **`RSQLite`**.
+**`tidyverse`.
 
 ### Windows
 


### PR DESCRIPTION
The setup instructions (first paragraph) mention that both tidyverse and RSQlite packages need to be installed. However, at the bottom of the page there are only instructions for tidyverse package installation and RSQlite package is not used during the course.
