### PR TITLE
Removed vector slicing from Key Points

### DIFF
--- a/_episodes_rmd/01-intro-to-r.Rmd
+++ b/_episodes_rmd/01-intro-to-r.Rmd
@@ -22,7 +22,6 @@ objectives:
 - "Analyze vectors with missing data."
 keypoints:
 - "Access individual values by location using `[]`."
-- "Access slices of data using `[low:high]`."
 - "Access arbitrary sets of data using `[c(...)]`."
 - "Use logical operations and logical vectors to access subsets of data."
 source: Rmd


### PR DESCRIPTION
Introduction to R > Key Points The second key point refers to slicing vectors, but this technique is not explained in the lesson. 