### PR TITLE
Fix df index as vector from [,1] to [[1]] in episode 02

### DIFF
--- a/_episodes_rmd/02-starting-with-data.Rmd
+++ b/_episodes_rmd/02-starting-with-data.Rmd
@@ -171,7 +171,7 @@ interviews[1, 1]
 ## first element in the 6th column (as a vector)
 interviews[1, 6]
 ## first column of the data frame (as a vector)
-interviews[, 1]
+interviews[[1]]
 ## first column of the data frame (as a data.frame)
 interviews[1]
 ## first three elements in the 7th column (as a vector)


### PR DESCRIPTION
For tibbles, `df[, 1]` produces a tibble not a vector