### PR TITLE
Exercise assumes lubridate is loaded from previous lesson

### DIFF
--- a/_episodes_rmd/03-dplyr-tidyr.Rmd
+++ b/_episodes_rmd/03-dplyr-tidyr.Rmd
@@ -380,6 +380,7 @@ interviews %>%
 > >
 > > ```{r}
 > > # if not already included, add month, year, and day columns
+> > library(lubridate) # load lubridate if not already loaded
 > > interviews %>%
 > >     mutate(month = month(interview_date),
 > >            day = day(interview_date),


### PR DESCRIPTION
Added `library(lubridate)` just in case. An alternative is to be explicit about the `package::function` (eg, `lubridate::month`).