### PR TITLE
Reformat figure caption links in Episode 00

### DIFF
--- a/_episodes_rmd/00-intro.Rmd
+++ b/_episodes_rmd/00-intro.Rmd
@@ -129,9 +129,7 @@ knitr::include_graphics("../fig/r+rstudio-analogy.jpg")
 ```
 <figcaption>
 RStudio extends what R can do, and makes it easier to write R code and interact
-with R. [Credit photo left
-photo](https://commons.wikimedia.org/w/index.php?curid=2447462), [Credit photo right
-photo](https://commons.wikimedia.org/w/index.php?curid=44599363)
+with R. <a href="https://commons.wikimedia.org/w/index.php?curid=2447462">Left photo credit</a>; <a href="https://commons.wikimedia.org/w/index.php?curid=44599363">right photo credit</a>. 
 </figcaption>
 </figure>
 


### PR DESCRIPTION
Responding to Issue #112 - I changed the photo credit links inside the <figcaption> tag from Markdown to HTML so they render when the website is viewed.

