### PR TITLE
issue #129: changing 'visualisation' to 'Visualisation' in a title.

### DIFF
--- a/_episodes_rmd/04-ggplot2.Rmd
+++ b/_episodes_rmd/04-ggplot2.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Data visualisation with ggplot2"
+title: "Data Visualisation with ggplot2"
 teaching: 80
 exercises: 35
 questions:


### PR DESCRIPTION
The lettercase in the titles of the episodes are not fully synchronized:

* Before we Start
* Starting with Data
* Data visualisation with ggplot2

Either we should change visualisation to Visualisation or Start to start and Data to data. According to the style guide (https://docs.carpentries.org/topic_folders/communications/resources/style-guide.html#c)

> Lesson titles and episodes within lessons should be rendered in Title case, i.e. all major words capitalised, e.g., Introduction to Data; Project Organisation and Management for Genomics.

This pull request changes "Data visualisation with ggplot2" to "Data Visualisation with ggplot2".