### PR TITLE
Change default branch to 'master' from 'gh-pages'.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,12 +106,12 @@ you may want to look at
 [How to Contribute to an Open Source Project on GitHub][how-contribute].
 In brief:
 
-1.  The published copy of the lesson is in the `gh-pages` branch of the repository
+1.  The published copy of the lesson is in the `master` branch of the repository
     (so that GitHub will regenerate it automatically).
     Please create all branches from that,
-    and merge the [master repository][repo]'s `gh-pages` branch into your `gh-pages` branch
+    and merge the [master repository][repo]'s `master` branch into your `master` branch
     before starting work.
-    Please do *not* work directly in your `gh-pages` branch,
+    Please do *not* work directly in your `master` branch,
     since that will make it difficult for you to work on other contributions.
 
 2.  We use [GitHub flow][github-flow] to manage changes:


### PR DESCRIPTION
The current contribution guide (CONTRIBUTING.md) states that contibutors should use 'gh-pages' as their starting point. Since Travis integration (see #116) this has been changed to 'master' branch. This pull request fixes the guide's relevant section.