### PR TITLE
Issue #132: 631 in long format rather than 131

### DIFF
--- a/_episodes_rmd/03-dplyr-tidyr.Rmd
+++ b/_episodes_rmd/03-dplyr-tidyr.Rmd
@@ -551,7 +551,7 @@ interviews_items_owned <- interviews %>%
 
 Then we use the new function `separate_rows()` to split the column `items_owned`
 based on the presence of semi-colons (`;`). This creates a long format version of the dataset. In this long
-format version, there are `r nrow(interviews_items_owned)` rows (one row for
+format version, there are `r nrow(interviews %>% separate_rows(items_owned, sep=";"))` rows (one row for
 each unique item for each respondent).
 
 ```{r, eval=FALSE}


### PR DESCRIPTION
This part of the lesson steps through a chain of pipes to talk about what each stage is doing. The current version uses inline code to pull the number of rows in the final data frame (interviews_items_owned). It needs to instead show the row count for an intermediate stage, after the separate_rows() call but before the spread(). I wasn't sure if it was better to have a (slightly clunky) inline calculation or just hard-code the number, and figured calculating it might be best.

First pull request, so if I've left out important information, let me know!