### PR TITLE
Update 03-dplyr-tidyr.md #804

### DIFF
--- a/_episodes/03-dplyr-tidyr.md
+++ b/_episodes/03-dplyr-tidyr.md
@@ -801,9 +801,9 @@ interviews_spread <- interviews %>%
 ~~~
 {: .language-r}
 
-View the `interviews_spread` data frame and notice that there is no longer a
-column titled `respondent_wall_type`. This is because there is a default
-parameter in `spread()` that drops the original column.
+Use name(interviews_spread), notice that there is no longer a column titled `respondent_wall_type`. 
+This is because there is a default parameter in `spread()` that drops the original column. Use dim(interviews)  and dim(interviews_spread) to compare number of columns. 
+
 
 ## Gathering
 


### PR DESCRIPTION
Please delete the text below before submitting your contribution. 

#804 change to:
Use name(interviews_spread), notice that there is no longer a column titled `respondent_wall_type`. 
This is because there is a default parameter in `spread()` that drops the original column. Use dim(interviews)  and dim(interviews_spread) to compare number of columns. 
