### PR TITLE
Update 04-ggplot2.Rmd - use geom_count instead of geom_jitter

### DIFF
--- a/_episodes_rmd/04-ggplot2.Rmd
+++ b/_episodes_rmd/04-ggplot2.Rmd
@@ -161,31 +161,38 @@ interviews_plotting %>%
 ```
 
 That only helped a little bit with the overplotting problem. We can make 
-the size of the dots representative of the number of items using the 
-`geom_count()` function
+the move the the dots by a random amount using the 
+`geom_jitter()` function so that they do not overlap.
 
 ```{r adding-count, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = no_membrs, y = number_items)) +
-    geom_count()
+    geom_jitter()
 ```
-The `geom_count()`  function makes the size of each point representative of the 
-number of data items of that type and the legend gives point sizes associated to
-particular numbers of items. We can also add colors for all the points:
+We can give limits on the amount of random motion so tha the points remain 
+clustered.  We can also add colors for all the points:
 
 ```{r adding-colors, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = no_membrs, y = number_items)) +
-    geom_count(alpha = 0.5, color = "blue")
+    geom_jitter(alpha = 0.5, color = "blue", width = 0.2, height = 0.2)
 ```
 
-Or to color each species in the plot differently, you could use a vector as an input to the argument **`color`**.  Because we are now mapping features of the data to a color, instead of setting one color for all points, the color now needs to be set inside a call to the **`aes`** function. **`ggplot2`** will provide a different color corresponding to different values in the vector. We set the value of **`alpha`** outside of the **`aes`** function call because we are using the same value for all points. Here is an example where we color by **`village`**:
+The width and height parameters give maximum limits of the cell size for random jitter
+displacements to be applied to points. Experiment with the values to see how your plot
+changes. To color each species in the plot differently, you could use a vector as an input 
+to the argument **`color`**.  Because we are now mapping features of the data to a color, 
+instead of setting one color for all points, the color now needs to be set inside a call 
+to the **`aes`** function. **`ggplot2`** will provide a different color corresponding 
+to different values in the vector. We set the value of **`alpha`** outside of the **`aes`** 
+function call because we are using the same value for all points. Here is an example 
+where we color by **`village`**:
 
 
 ```{r color-by-species, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = no_membrs, y = number_items)) +
-    geom_count(aes(color = village), alpha = 0.5)
+    geom_jitter(aes(color = village), alpha = 0.5, width = 0.2, height = 0.2)
 ```
 
 There appears to be a positive trend between number of household
@@ -195,19 +202,32 @@ does not appear to be different by village.
 > ## Exercise
 >
 > Use what you just learned to create a scatter plot of `rooms` by `village`
-> with the `respondent_wall_type` showing in different colors. Is this a good
-> way to show this type of data?
+> with the `respondent_wall_type` showing in different colors. What
+> other kinds of plots might you use to show this type of data?
 >
 > > ## Solution
 > >
 > > ```{r scatter-challenge, answer=TRUE, purl=FALSE}
 > > interviews_plotting %>%
 > >     ggplot(aes(x = village, y = rooms)) +
-> >     geom_count(aes(color = respondent_wall_type))
+> >     geom_jitter(aes(color = respondent_wall_type), alpha = 0.5, width = 0.25, height = 0.25)
 > > ```
-> > This is not the best way to show this type of data because it is difficult to
-> > distinguish between `respondent_wall_type` in houses in the same `village` with the
-> > same number of `rooms`. Changing the alpha setting is helpful in such a situation.
+> >
+> > There are multiple ways to make plots. One other way to plot the data is 
+> > to use the `geom_count` plotting function. The `geom_count()`  function 
+> > makes the size of each point representative of the number of data items 
+> > of that type and the legend gives point sizes associated to particular 
+> > numbers of items.
+> >
+> > ```{r scatter-challenge, answer=TRUE, purl=FALSE}
+> > interviews_plotting %>%
+> >     ggplot(aes(x = village, y = rooms)) +
+> >     geom_count(aes(color = respondent_wall_type), shape = 22, alpha = 0.75)
+> > ```
+> > For both of these plots, it is difficult to distinguish between `respondent_wall_type`
+> > in houses in the same `village` with the same number of `rooms`. Changing the alpha 
+> > setting is a partial solution. See https://ggplot2.tidyverse.org/articles/ggplot2-specs.html
+>> to find other shapes you can use. What other plot types can help you visualize this data well?
 > {: .solution}
 {: .challenge}
 
@@ -229,7 +249,7 @@ measurements and of their distribution:
 ```{r boxplot-with-count, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = respondent_wall_type, y = rooms)) +
-    geom_count(alpha = 0.5, color = "tomato") +
+    geom_jitter(alpha = 0.5, color = "tomato", width = 0.25, height = 0.25) +
     geom_boxplot(alpha = 0) 
 ```
 
@@ -255,7 +275,7 @@ correspoinding to cement is not hidden?
 > > interviews_plotting %>%
 > >   ggplot(aes(x = respondent_wall_type, y = rooms)) +
 > >   geom_violin(alpha = 0) +
-> >   geom_count(alpha = 0.5, color = "tomato")
+> >   geom_jitter(alpha = 0.5, color = "tomato")
 > > ```
 > {: .solution}
 >
@@ -271,7 +291,7 @@ correspoinding to cement is not hidden?
 > > interviews_plotting %>%
 > >    ggplot(aes(x = respondent_wall_type, y = liv_count)) +
 > >    geom_boxplot(alpha = 0) +
-> >    geom_count(alpha = 0.5)
+> >    geom_jitter(alpha = 0.5, width = 0.25, height = 0.25)
 > > ```
 > {: .solution}
 >
@@ -283,7 +303,7 @@ correspoinding to cement is not hidden?
 > > interviews_plotting %>%
 > >   ggplot(aes(x = respondent_wall_type, y = liv_count)) +
 > >   geom_boxplot(alpha = 0) +
-> >   geom_count(aes(color = memb_assoc),alpha=0.5)
+> >   geom_jitter(aes(color = memb_assoc), alpha = 0.5, width = 0.25, height = 0.25)
 > > ```
 > {: .solution}
 {: .challenge}

--- a/_episodes_rmd/04-ggplot2.Rmd
+++ b/_episodes_rmd/04-ggplot2.Rmd
@@ -276,8 +276,8 @@ this trend does not appear to be different by village.
 > >     ggplot(aes(x = village, y = rooms)) +
 > >     geom_jitter(aes(color = respondent_wall_type),
 > >		    alpha = 0.5,
-> > 		    width = 0.25,
-> > 		    height = 0.25)
+> > 		    width = 0.2,
+> > 		    height = 0.2)
 > > ```
 > >
 > > This is not a great way to show this type of data because it is difficult to
@@ -307,8 +307,8 @@ interviews_plotting %>%
     geom_boxplot(alpha = 0) +
     geom_jitter(alpha = 0.5,
     		color = "tomato",
-    		width = 0.25,
-		height = 0.25) +
+    		width = 0.2,
+    		height = 0.2) +
 ```
 
 We can see that muddaub houses and sunbrick houses tend to be smaller than
@@ -349,7 +349,7 @@ hidden?
 > > interviews_plotting %>%
 > >    ggplot(aes(x = respondent_wall_type, y = liv_count)) +
 > >    geom_boxplot(alpha = 0) +
-> >    geom_jitter(alpha = 0.5, width = 0.25, height = 0.25)
+> >    geom_jitter(alpha = 0.5, width = 0.2, height = 0.2)
 > > ```
 > {: .solution}
 >
@@ -361,7 +361,7 @@ hidden?
 > > interviews_plotting %>%
 > >   ggplot(aes(x = respondent_wall_type, y = liv_count)) +
 > >   geom_boxplot(alpha = 0) +
-> >   geom_jitter(aes(color = memb_assoc), alpha = 0.5, width = 0.25, height = 0.25)
+> >   geom_jitter(aes(color = memb_assoc), alpha = 0.5, width = 0.2, height = 0.2)
 > > ```
 > {: .solution}
 {: .challenge}

--- a/_episodes_rmd/04-ggplot2.Rmd
+++ b/_episodes_rmd/04-ggplot2.Rmd
@@ -151,11 +151,28 @@ interviews_plotting %>%
 ```
 
 Then, we start modifying this plot to extract more information from it. For
-instance, we can add transparency (`alpha`) as an argument to `geom_point` 
-to avoid overplotting, which means that overlapping points become invisible. 
-Adding transparency begins to address this problem, as overlapping dots become 
-darker:
+instance, when inspecting the plot we notice that points only appear at the 
+intersection of whole numbers of `no_membrs` and `number_items`. Also, from a 
+rough estimate, it looks like there are far fewer dots on the plot than there 
+rows in our dataframe. This should lead us to believe that there may be multiple
+observations plotted on top of each other (e.g. three observations where 
+`no_membrs` is 3 and `number_items` is 1). 
 
+There are two main ways to alleviate overplotting issues: 
+1. changing the transparency of the points 
+2. jittering the location of the points
+
+Let's first explore option 1, changing the transparency of the points. What we 
+mean when we say "transparency" we mean the opacity of point, or your ability to 
+see through the point. We can control the transparency of the points with the 
+`alpha` argument to `geom_point`. Values of `alpha` range from 0 to 1, with
+lower values corresponding to more transparent colors (an `alpha` of 1 is the 
+default value). 
+
+Here, we change the `alpha` to 0.5, in an attempt to help fix the overplotting. 
+While the overplotting isn't solved, adding transparency begins to address this
+problem, as the points where there are overlapping observations are darker (as 
+opposed to lighter gray):
 
 ```{r adding-transparency, purl=FALSE}
 interviews_plotting %>%
@@ -163,34 +180,59 @@ interviews_plotting %>%
     geom_point(alpha = 0.5)
 ```
 
-That only helped a little bit with the overplotting problem. We can make 
-the move the the dots by a random amount using the 
-`geom_jitter()` function so that they do not overlap.
+That only helped a little bit with the overplotting problem, so let's try option
+two. We can jitter the points on the plot, so that we can see each point in the
+locations where there are overlapping points. Jittering introduces a little bit
+of randomness into the position of our points. You can think of this process as 
+taking the overplotted graph and giving it a tiny shake. The points will move a 
+little bit side-to-side and up-and-down, but their position from the original 
+plot won't dramatically change. 
 
-```{r adding-count, purl=FALSE}
+We can jitter our points using the `geom_jitter()` function instead of the
+`geom_point()`  function, as seen below:
+
+```{r adding-jitter, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = no_membrs, y = number_items)) +
     geom_jitter()
 ```
-We can give limits on the amount of random motion so tha the points remain 
-clustered.  We can also add colors for all the points:
+The `geom_jitter()` function allows for us to specify the amount of random
+motion in the jitter, using the `width` and `height` arguments. When we don't 
+specify values for `width` and `height`, `geom_jitter()` defaults to 40% of the
+resolution of the data (the smallest change that can be measured). Hence, if we 
+would like *less* spread in our jitter than was default, we should pick values 
+between 0.1 and 0.4. Experiment with the values to see how your plot changes.
+
+```{r adding-width-height, purl=FALSE}
+interviews_plotting %>%
+    ggplot(aes(x = no_membrs, y = number_items)) +
+    geom_jitter(alpha = 0.5,
+                width = 0.2,
+                height = 0.2)
+```
+
+For our final change, we can also add colors for all the points by specifying 
+a `color` argument inside the `geom_jitter()` function:
 
 ```{r adding-colors, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = no_membrs, y = number_items)) +
-    geom_jitter(alpha = 0.5, color = "blue", width = 0.2, height = 0.2)
+    geom_jitter(alpha = 0.5,
+                color = "blue",
+                width = 0.2,
+                height = 0.2)
 ```
 
-The width and height parameters give maximum limits of the cell size for random jitter
-displacements to be applied to points. Experiment with the values to see how your plot
-changes. To color each species in the plot differently, you could use a vector as an input 
-to the argument **`color`**.  Because we are now mapping features of the data to a color, 
-instead of setting one color for all points, the color now needs to be set inside a call 
-to the **`aes`** function. **`ggplot2`** will provide a different color corresponding 
-to different values in the vector. We set the value of **`alpha`** outside of the **`aes`** 
-function call because we are using the same value for all points. Here is an example 
-where we color by **`village`**:
-
+To color each species in the plot differently, you could use a vector as an input 
+to the argument **`color`**.  However, because we are now mapping features of the
+data to a color, instead of setting one color for all points, the color of the 
+points now needs to be set inside a call to the **`aes`** function. When we map 
+a variable in our data to the color of the points, **`ggplot2`** will provide a
+different color corresponding to the different values of the variable. We will 
+continue to specify the value of **`alpha`**, **`width`**, and **`height`**
+outside of the **`aes`** function because we are using the same value for 
+every point. Here is an example where we color points by the **`village`** 
+of the observation:
 
 
 ```{r color-by-species, purl=FALSE}
@@ -200,38 +242,47 @@ interviews_plotting %>%
 ```
 
 There appears to be a positive trend between number of household
-members and number of items owned (from the list provided). This trend
-does not appear to be different by village.
+members and number of items owned (from the list provided). Additionally, 
+this trend does not appear to be different by village.
+
+> ## Notes 
+> 
+> As you will learn, there are multiple ways to plot the a relationship
+> between variables. Another way to plot data with overlapping points is 
+> to use the `geom_count` plotting function. The `geom_count()`  function 
+> makes the size of each point representative of the number of data items 
+> of that type and the legend gives point sizes associated to particular 
+> numbers of items. 
+>
+> ```{r color-by-species, purl=FALSE}
+> interviews_plotting %>% 
+>    ggplot(aes(x = no_membrs, y = number_items, color = village)) +
+>    geom_count()
+> ```    
+
+{: .callout}
 
 > ## Exercise
 >
 > Use what you just learned to create a scatter plot of `rooms` by `village`
-> with the `respondent_wall_type` showing in different colors. What
-> other kinds of plots might you use to show this type of data?
+> with the `respondent_wall_type` showing in different colors. Does this 
+> seem like a good way to display the relationship between these variables? 
+> What other kinds of plots might you use to show this type of data?
 >
 > > ## Solution
 > >
 > > ```{r scatter-challenge, answer=TRUE, purl=FALSE}
 > > interviews_plotting %>%
 > >     ggplot(aes(x = village, y = rooms)) +
-> >     geom_jitter(aes(color = respondent_wall_type), alpha = 0.5, width = 0.25, height = 0.25)
+> >     geom_jitter(aes(color = respondent_wall_type),
+> >		    alpha = 0.5,
+> > 		    width = 0.25,
+> > 		    height = 0.25)
 > > ```
 > >
-> > There are multiple ways to make plots. One other way to plot the data is 
-> > to use the `geom_count` plotting function. The `geom_count()`  function 
-> > makes the size of each point representative of the number of data items 
-> > of that type and the legend gives point sizes associated to particular 
-> > numbers of items.
-> >
-> > ```{r scatter-challenge, answer=TRUE, purl=FALSE}
-> > interviews_plotting %>%
-> >     ggplot(aes(x = village, y = rooms)) +
-> >     geom_count(aes(color = respondent_wall_type), shape = 22, alpha = 0.75)
-> > ```
-> > For both of these plots, it is difficult to distinguish between `respondent_wall_type`
-> > in houses in the same `village` with the same number of `rooms`. Changing the alpha 
-> > setting is a partial solution. See https://ggplot2.tidyverse.org/articles/ggplot2-specs.html
->> to find other shapes you can use. What other plot types can help you visualize this data well?
+> > This is not a great way to show this type of data because it is difficult to
+> > distinguish between villages. What other plot types could help you visualize
+> > this relationship better?
 > {: .solution}
 {: .challenge}
 
@@ -250,19 +301,22 @@ interviews_plotting %>%
 By adding points to a boxplot, we can have a better idea of the number of
 measurements and of their distribution:
 
-```{r boxplot-with-count, purl=FALSE}
+```{r boxplot-with-jitter, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = respondent_wall_type, y = rooms)) +
-    geom_jitter(alpha = 0.5, color = "tomato", width = 0.25, height = 0.25) +
-    geom_boxplot(alpha = 0) 
+    geom_boxplot(alpha = 0) +
+    geom_jitter(alpha = 0.5,
+    		color = "tomato",
+    		width = 0.25,
+		height = 0.25) +
 ```
 
 We can see that muddaub houses and sunbrick houses tend to be smaller than
 burntbrick houses.
 
-Notice how the count layer is behind the boxplot layer? What do you need to
-change in the code to put the boxplot in behind the points such that the point
-correspoinding to cement is not hidden?
+Notice how the  boxplot layer is behind the jitter layer? What do you need to
+change in the code to put the boxplot in behind the points such that it's not 
+hidden?
 
 > ## Exercise
 >
@@ -288,7 +342,7 @@ correspoinding to cement is not hidden?
 > type.
 >
 > - Create a boxplot for `liv_count` for each wall type. Overlay the boxplot
->   layer on a count layer to show actual measurements.
+>   layer on a jitter layer to show actual measurements.
 >
 > > ## Solution
 > > ```{r boxplot-exercise}

--- a/_episodes_rmd/04-ggplot2.Rmd
+++ b/_episodes_rmd/04-ggplot2.Rmd
@@ -254,7 +254,7 @@ this trend does not appear to be different by village.
 > of that type and the legend gives point sizes associated to particular 
 > numbers of items. 
 >
-> ```{r color-by-species, purl=FALSE}
+> ```{r color-by-species-notes, purl=FALSE}
 > interviews_plotting %>% 
 >    ggplot(aes(x = no_membrs, y = number_items, color = village)) +
 >    geom_count()

--- a/_episodes_rmd/04-ggplot2.Rmd
+++ b/_episodes_rmd/04-ggplot2.Rmd
@@ -149,9 +149,10 @@ interviews_plotting %>%
 ```
 
 Then, we start modifying this plot to extract more information from it. For
-instance, we can add transparency (`alpha`) as an argument to `geom_point` to avoid overplotting, which means
-that overlapping points become invisible. Adding transparency begins to address
-this problem, as overlapping dots become darker:
+instance, we can add transparency (`alpha`) as an argument to `geom_point` 
+to avoid overplotting, which means that overlapping points become invisible. 
+Adding transparency begins to address this problem, as overlapping dots become 
+darker:
 
 ```{r adding-transparency, purl=FALSE}
 interviews_plotting %>%
@@ -168,7 +169,9 @@ interviews_plotting %>%
     ggplot(aes(x = no_membrs, y = number_items)) +
     geom_count()
 ```
-We can also add colors for all the points:
+The `geom_count()`  function makes the size of each point representative of the 
+number of data items of that type and the legend gives point sizes associated to
+particular numbers of items. We can also add colors for all the points:
 
 ```{r adding-colors, purl=FALSE}
 interviews_plotting %>%
@@ -202,8 +205,9 @@ does not appear to be different by village.
 > >     ggplot(aes(x = village, y = rooms)) +
 > >     geom_count(aes(color = respondent_wall_type))
 > > ```
-> > This is not a good way to show this type of data because it is difficult to
-> > distinguish between villages.
+> > This is not the best way to show this type of data because it is difficult to
+> > distinguish between `respondent_wall_type` in houses in the same `village` with the
+> > same number of `rooms`. Changing the alpha setting is helpful in such a situation.
 > {: .solution}
 {: .challenge}
 
@@ -222,19 +226,19 @@ interviews_plotting %>%
 By adding points to a boxplot, we can have a better idea of the number of
 measurements and of their distribution:
 
-```{r boxplot-with-points, purl=FALSE}
+```{r boxplot-with-count, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = respondent_wall_type, y = rooms)) +
-    geom_boxplot(alpha = 0) +
-    geom_jitter(alpha = 0.5, color = "tomato")
+    geom_count(alpha = 0.5, color = "tomato") +
+    geom_boxplot(alpha = 0) 
 ```
 
 We can see that muddaub houses and sunbrick houses tend to be smaller than
 burntbrick houses.
 
-Notice how the boxplot layer is behind the jitter layer? What do you need to
-change in the code to put the boxplot in front of the points such that it's not
-hidden?
+Notice how the count layer is behind the boxplot layer? What do you need to
+change in the code to put the boxplot in behind the points such that the point
+correspoinding to cement is not hidden?
 
 > ## Exercise
 >

--- a/_episodes_rmd/04-ggplot2.Rmd
+++ b/_episodes_rmd/04-ggplot2.Rmd
@@ -159,30 +159,21 @@ interviews_plotting %>%
     geom_point(alpha = 0.5)
 ```
 
-That only helped a little bit with the overplotting problem. We can create a new data make 
-the size of the dots representative of the number of items
+That only helped a little bit with the overplotting problem. We can make 
+the size of the dots representative of the number of items using the 
+`geom_count()` function
 
-```{r create-ggplot-object, purl=FALSE}
-select(interviews_plotting,no_membrs,number_items) %>%
-  count(no_membrs, number_items) %>%
-  ggplot(aes(x = no_membrs, y = number_items)) +
-  geom_point(aes(size = n))
-```
-We can also introduce a little bit of randomness into the position of our points
-using the `geom_jitter()` function.
-
-```{r adding-jitter, purl=FALSE}
+```{r adding-count, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = no_membrs, y = number_items)) +
-    geom_jitter(alpha = 0.5)
+    geom_count()
 ```
-
 We can also add colors for all the points:
 
 ```{r adding-colors, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = no_membrs, y = number_items)) +
-    geom_jitter(alpha = 0.5, color = "blue")
+    geom_count(alpha = 0.5, color = "blue")
 ```
 
 Or to color each species in the plot differently, you could use a vector as an input to the argument **`color`**.  Because we are now mapping features of the data to a color, instead of setting one color for all points, the color now needs to be set inside a call to the **`aes`** function. **`ggplot2`** will provide a different color corresponding to different values in the vector. We set the value of **`alpha`** outside of the **`aes`** function call because we are using the same value for all points. Here is an example where we color by **`village`**:
@@ -191,7 +182,7 @@ Or to color each species in the plot differently, you could use a vector as an i
 ```{r color-by-species, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = no_membrs, y = number_items)) +
-    geom_jitter(aes(color = village), alpha = 0.5)
+    geom_count(aes(color = village), alpha = 0.5)
 ```
 
 There appears to be a positive trend between number of household
@@ -209,7 +200,7 @@ does not appear to be different by village.
 > > ```{r scatter-challenge, answer=TRUE, purl=FALSE}
 > > interviews_plotting %>%
 > >     ggplot(aes(x = village, y = rooms)) +
-> >     geom_jitter(aes(color = respondent_wall_type))
+> >     geom_count(aes(color = respondent_wall_type))
 > > ```
 > > This is not a good way to show this type of data because it is difficult to
 > > distinguish between villages.
@@ -260,7 +251,7 @@ hidden?
 > > interviews_plotting %>%
 > >   ggplot(aes(x = respondent_wall_type, y = rooms)) +
 > >   geom_violin(alpha = 0) +
-> >   geom_jitter(alpha = 0.5, color = "tomato")
+> >   geom_count(alpha = 0.5, color = "tomato")
 > > ```
 > {: .solution}
 >
@@ -269,14 +260,14 @@ hidden?
 > type.
 >
 > - Create a boxplot for `liv_count` for each wall type. Overlay the boxplot
->   layer on a jitter layer to show actual measurements.
+>   layer on a count layer to show actual measurements.
 >
 > > ## Solution
 > > ```{r boxplot-exercise}
 > > interviews_plotting %>%
 > >    ggplot(aes(x = respondent_wall_type, y = liv_count)) +
 > >    geom_boxplot(alpha = 0) +
-> >    geom_jitter(alpha = 0.5)
+> >    geom_count(alpha = 0.5)
 > > ```
 > {: .solution}
 >
@@ -288,7 +279,7 @@ hidden?
 > > interviews_plotting %>%
 > >   ggplot(aes(x = respondent_wall_type, y = liv_count)) +
 > >   geom_boxplot(alpha = 0) +
-> >   geom_jitter(aes(alpha = 0.5, color = memb_assoc))
+> >   geom_count(aes(color = memb_assoc),alpha=0.5)
 > > ```
 > {: .solution}
 {: .challenge}

--- a/_episodes_rmd/04-ggplot2.Rmd
+++ b/_episodes_rmd/04-ggplot2.Rmd
@@ -159,8 +159,16 @@ interviews_plotting %>%
     geom_point(alpha = 0.5)
 ```
 
-That only helped a little bit with the overplotting problem. We can also
-introduce a little bit of randomness into the position of our points
+That only helped a little bit with the overplotting problem. We can create a new data make 
+the size of the dots representative of the number of items
+
+```{r create-ggplot-object, purl=FALSE}
+select(interviews_plotting,no_membrs,number_items) %>%
+  count(no_membrs, number_items) %>%
+  ggplot(aes(x = no_membrs, y = number_items)) +
+  geom_point(aes(size = n))
+```
+We can also introduce a little bit of randomness into the position of our points
 using the `geom_jitter()` function.
 
 ```{r adding-jitter, purl=FALSE}
@@ -168,7 +176,6 @@ interviews_plotting %>%
     ggplot(aes(x = no_membrs, y = number_items)) +
     geom_jitter(alpha = 0.5)
 ```
-
 
 We can also add colors for all the points:
 


### PR DESCRIPTION
 Add additional plot that illustrates quantities better. If worth including, probably want to modify this part of the lesson a little to keep time. Maybe replace all geom_jitter plots with geom_point. Can reduce discussion on using alpha, and keep discussion on using color and add different shapes. Could also use [geom_count](https://ggplot2.tidyverse.org/reference/geom_count.html) instead of  geom_jitter.
