### PR TITLE
Lesson check fixes

### DIFF
--- a/_episodes_rmd/03-dplyr-tidyr.Rmd
+++ b/_episodes_rmd/03-dplyr-tidyr.Rmd
@@ -874,7 +874,7 @@ write_csv(interviews_plotting, path = "data_output/interviews_plotting.csv")
 
 ```{r, purl = FALSE, eval = TRUE, echo = FALSE}
 if (!dir.exists("data_output")) dir.create("data_output")
-write_csv(interviews_plotting, path = "data_output/interviews_plotting.csv")
+write_csv(interviews_plotting, file = "data_output/interviews_plotting.csv")
 ```
 
 {% include links.md %}

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,5 +1,0 @@
----
-layout: page
-title: Discussion
----
-FIXME


### PR DESCRIPTION
Fixing some minor issues that are causing `make lesson-check` to fail. 

- Delete `_extras\discuss.md` as it does not serve an immediate purpose, nor do I see other lessons using this
- Fix deprecation warning in ep 03