### PR TITLE
Coerce flattened array to tibble for write_csv

### DIFF
--- a/_episodes_rmd/05-json.Rmd
+++ b/_episodes_rmd/05-json.Rmd
@@ -126,7 +126,8 @@ To write out as a csv, we will need to "flatten" these columns. One thing you ca
 
 ```{r}
 
-flattened_json_data <- apply(json_data,2,as.character)
+flattened_json_data <- apply(json_data,2,as.character) %>%
+  as_tibble()
 
 ```
 


### PR DESCRIPTION
Flattening list columns in json data frame coerces object to matrix and thus `write_csv` does not work. Coerced object back to tibble