### PR TITLE
adding the file name earlier

### DIFF
--- a/_episodes_rmd/02-starting-with-data.Rmd
+++ b/_episodes_rmd/02-starting-with-data.Rmd
@@ -63,7 +63,7 @@ in other lessons in this workshop, see the
 [dataset description](http://www.datacarpentry.org/socialsci-workshop/data/).
 
 We will be using a subset of the cleaned version of the dataset that
-was produced through cleaning in OpenRefine. Each row holds
+was produced through cleaning in OpenRefine (`SAFI_clean.csv`). Each row holds
 information for a single interview respondent, and the columns
 represent:
 

--- a/_episodes_rmd/02-starting-with-data.Rmd
+++ b/_episodes_rmd/02-starting-with-data.Rmd
@@ -63,7 +63,7 @@ in other lessons in this workshop, see the
 [dataset description](http://www.datacarpentry.org/socialsci-workshop/data/).
 
 We will be using a subset of the cleaned version of the dataset that
-was produced through cleaning in OpenRefine (`SAFI_clean.csv`). Each row holds
+was produced through cleaning in OpenRefine (`data/SAFI_clean.csv`). Each row holds
 information for a single interview respondent, and the columns
 represent:
 


### PR DESCRIPTION
I'm adding a small reference to the file name earlier. I didn't see that it was referenced later on in the code examples, but it would be nice to have it earlier when the data is being discussed.  Going to the figshare deposit there are SAFI_clean and SAFI_openrefine, and the directions weren't really clear which one to download.