### PR TITLE
simplifying some of the object terms for tibbles

### DIFF
--- a/_episodes_rmd/02-starting-with-data.Rmd
+++ b/_episodes_rmd/02-starting-with-data.Rmd
@@ -145,12 +145,7 @@ interviews
 
 Note that `read_csv()` actually loads the data as a tibble.
 A tibble is an extension of `R` data frames used by the **`tidyverse`**. When the
-data is read using `read_csv()`, it is stored in an object of class `tbl_df`,
-`tbl`,  and `data.frame`. You can see the class of an object with
-
-```{r results='hold', purl=FALSE}
-class(interviews)
-```
+data is read using `read_csv()`.
 
 As a `tibble`, the type of data included in each column is listed in an
 abbreviated fashion below the column names. For instance, here `key_ID` is a
@@ -160,7 +155,7 @@ column of integers (abbreviated `<int>`), `village` is a column of characters
 
 ## Inspecting data frames
 
-When calling a `tbl_df` object (like `interviews` here), there is already a lot of information about our data frame being displayed such as the number of rows, the number of columns, the names of the columns, and as we just saw the class of data stored in each column. However, there are functions to extract this information from data frames.  Here is a non-exhaustive list of some of these
+When viewing a `tibble` in the R console, like we did with `interviews` here, there is already a lot of information about our data frame being displayed such as the number of rows, the number of columns, the names of the columns, and as we just saw the class of data stored in each column. However, there are functions to extract this information from data frames.  Here is a non-exhaustive list of some of these
 functions. Let's try them out!
 
 Size:
@@ -194,7 +189,7 @@ objects besides data frames or tibbles.
 
 ## Indexing and subsetting data frames
 
-Our `interviews` data frame has rows and columns (it has 2 dimensions).
+Our `interviews` `tibble` has rows and columns (it has 2 dimensions).
 In practice, we may not need the entire data frame; for instance, we may only
 be interested in a subset of the observations (the rows) or a particular set
 of variables (the columns). If we want to


### PR DESCRIPTION
I'm fully understanding if this is rejected or needs some discussion.

In reviewing this lesson as prep to teach with it, I found this section particularly confusing.  This is first showcasing the output of `class(interviews)` but really not discussing  what these results mean. Then it goes right into talking about the date types for the columns. With that column discussion right under this demo code, I didn't realize it was referring to other examples. 

My view on this is as follows: if you aren't going to discuss the output of `class(...)` here or really dive into that later in the lesson, then it should be taken out.  I also took out the reference to 'calling' and made it a bit more generic.  The next section also refers to `interviews` as a data frame, but it's still a tibble?  

For another day, data frames are referred to with regular text but tibble is mostly put in as inline code. That's a larger thing that should be separate.