### PR TITLE
Replace illustration of & with a range that doesn't give an empty result

### DIFF
--- a/_episodes_rmd/01-intro-to-r.Rmd
+++ b/_episodes_rmd/01-intro-to-r.Rmd
@@ -484,7 +484,7 @@ You can combine multiple tests using `&` (both conditions are true, AND) or `|`
 
 ```{r, results='show', purl=FALSE}
 hh_members[hh_members < 4 | hh_members > 7]
-hh_members[hh_members >= 7 & hh_members == 3]
+hh_members[hh_members >= 4 & hh_members <= 7]
 ```
 
 Here, `<` stands for "less than", `>` for "greater than", `>=` for "greater than


### PR DESCRIPTION
- Fixes Issue #317
- Replace the example of `&` in the 01 Intro to R lesson (peviously it was ">= 7 | == 3` which is necessarily empty; replaced that with the opposite of the `|` example above it)
