### PR TITLE
Correct minor grammar mistake

### DIFF
--- a/_episodes_rmd/03-dplyr-tidyr.Rmd
+++ b/_episodes_rmd/03-dplyr-tidyr.Rmd
@@ -93,7 +93,7 @@ and this [one about **`tidyr`**](https://github.com/rstudio/cheatsheets/raw/mast
 
 ## Learning **`dplyr`** and **`tidyr`**
 
-To make sure, everyone will use the same dataset for this lesson, we'll read
+To make sure everyone will use the same dataset for this lesson, we'll read
 again the SAFI dataset that we downloaded earlier.
 
 ```{r, results = 'hide', purl = FALSE, message = FALSE}


### PR DESCRIPTION
Change from "To make sure, everyone will use the same dataset for this lesson, we'll read again the SAFI dataset that we downloaded earlier." to "To make sure everyone will use the same dataset for this lesson, we'll read again the SAFI dataset that we downloaded earlier." Deleting the comma.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
