### PR TITLE
Workflow missing script to download SAFI data for the site

### DIFF
--- a/bin/install_r_deps.sh
+++ b/bin/install_r_deps.sh
@@ -1,1 +1,1 @@
-Rscript -e "source(file.path('bin', 'dependencies.R')); install_required_packages(); install_dependencies(identify_dependencies())"
+Rscript -e "source(file.path('bin', 'dependencies.R')); source(file.path('bin', 'download_data.R')); install_required_packages(); install_dependencies(identify_dependencies())"


### PR DESCRIPTION
Added `bin/download_data.R` to the `install_r_deps.sh` script, since SAFI data is currently missing from site eg, #334