### PR TITLE
fixed typo in year mentioned in 02-starting-with-data

### DIFF
--- a/_episodes_rmd/02-starting-with-data.Rmd
+++ b/_episodes_rmd/02-starting-with-data.Rmd
@@ -577,7 +577,7 @@ them to the appropriate `Date/POSIXct`format.
 Let's say we have a vector of dates in character format:
 
 ```{r, purl = FALSE}
-char_dates <- c("7/31/2012", "8/9/2014", "4/30/2106")
+char_dates <- c("7/31/2012", "8/9/2014", "4/30/2016")
 str(char_dates)
 ```
 


### PR DESCRIPTION
The section on "Formatting Dates", in the lesson entitled "Starting with data" (https://datacarpentry.org/r-socialsci/02-starting-with-data/index.html) appears to contain a small typing error. 

In the vector of dates in characters format, the third date is 2106:

char_dates <- c("7/31/2012", "8/9/2014", "4/30/2106") 

I am guessing that this should have been 2016. This can be confusing for learners. 

 