### PR TITLE
Updated broken R Markdown cheet sheet link

### DIFF
--- a/_episodes_rmd/05-rmarkdown.Rmd
+++ b/_episodes_rmd/05-rmarkdown.Rmd
@@ -471,7 +471,7 @@ output: word_document
 * [Knitr in a knutshell tutorial](http://kbroman.org/knitr_knutshell)
 * [Dynamic Documents with R and knitr](http://www.amazon.com/exec/obidos/ASIN/1482203537/7210-20) (book)
 * [R Markdown documentation](http://rmarkdown.rstudio.com)
-* [R Markdown cheat sheet](https://www.rstudio.com/wp-content/uploads/2016/03/rmarkdown-cheatsheet-2.0.pdf)
+* [R Markdown cheat sheet](https://github.com/rstudio/cheatsheets/blob/master/rmarkdown-2.0.pdf)
 * [Getting started with R Markdown](https://www.rstudio.com/resources/webinars/getting-started-with-r-markdown/)
 * [Markdown tutorial](https://commonmark.org/help/tutorial/)
 * [R Markdown: The Definitive Guide](https://bookdown.org/yihui/rmarkdown/) (book by Rstudio team)


### PR DESCRIPTION
Hi! While reading through the R Markdown episode, I noticed the R Markdown cheat sheet link was not working. I added the link to the cheatsheet on GitHub. The link to 'The Ecosystem of R Markdown' is broken too, but I could not find the correct replacement for that.