### PR TITLE
fix image credit for illustrations by Allison Horst

### DIFF
--- a/_episodes_rmd/02-starting-with-data.Rmd
+++ b/_episodes_rmd/02-starting-with-data.Rmd
@@ -103,7 +103,15 @@ inside your project, like analysis projects with data and reports in different
 subdirectories.  This is an important contrast to using `setwd()`, which 
 depends on the way you order your files on your computer. 
 
-![Illustration by [Allison Horst](https://github.com/allisonhorst)](../fig/here_horst.png)
+<figure>
+```{r here-figure, echo = FALSE, fig.show = "hold", fig.alt = "Monsters at a fork in the road, with signs saying here, and not here. One direction, not here, leads to a scary dark forest with spiders and absolute filepaths, while the other leads to a sunny, green meadow, and a city below a rainbow and a world free of absolute filepaths. Art by Alliso Horst", out.width="100%"}
+knitr::include_graphics("../fig/here_horst.png")
+```
+<figcaption>
+Image credit: <a href="https://github.com/allisonhorst/stats-illustrations">Allison Horst</a>
+</figcaption>
+</figure>
+
 
 Before we can use the `read_csv()` and `here()` functions, we need to load the 
 tidyverse and here packages.

--- a/_episodes_rmd/02-starting-with-data.Rmd
+++ b/_episodes_rmd/02-starting-with-data.Rmd
@@ -104,7 +104,7 @@ subdirectories.  This is an important contrast to using `setwd()`, which
 depends on the way you order your files on your computer. 
 
 <figure>
-```{r here-figure, echo = FALSE, fig.show = "hold", fig.alt = "Monsters at a fork in the road, with signs saying here, and not here. One direction, not here, leads to a scary dark forest with spiders and absolute filepaths, while the other leads to a sunny, green meadow, and a city below a rainbow and a world free of absolute filepaths. Art by Alliso Horst", out.width="100%"}
+```{r here-figure, echo = FALSE, fig.show = "hold", fig.alt = "Monsters at a fork in the road, with signs saying here, and not here. One direction, not here, leads to a scary dark forest with spiders and absolute filepaths, while the other leads to a sunny, green meadow, and a city below a rainbow and a world free of absolute filepaths. Art by Allison Horst", out.width="100%"}
 knitr::include_graphics("../fig/here_horst.png")
 ```
 <figcaption>

--- a/_episodes_rmd/05-rmarkdown.Rmd
+++ b/_episodes_rmd/05-rmarkdown.Rmd
@@ -42,7 +42,15 @@ making any changes in the actual document.
 The **rmarkdown** package comes pre-installed with RStudio, so no action is 
 necessary.
 
-![R Markdown wizard monsters creating a R Markdown document from a recipe. Art by Alliso Horst (<https://github.com/allisonhorst>)](../fig/rmarkdown_wizards.png)
+<figure>
+```{r rmarkdown-wizards, echo = FALSE, fig.show = "hold", fig.alt = "R Markdown wizard monsters creating a R Markdown document from a recipe. Art by Alliso Horst", out.width="100%"}
+knitr::include_graphics("../fig/rmarkdown_wizards.png")
+```
+<figcaption>
+Image credit: <a href="https://github.com/allisonhorst/stats-illustrations">Allison Horst</a>
+</figcaption>
+</figure>
+
 
 ## Creating an R Markdown file
 

--- a/_episodes_rmd/05-rmarkdown.Rmd
+++ b/_episodes_rmd/05-rmarkdown.Rmd
@@ -43,7 +43,7 @@ The **rmarkdown** package comes pre-installed with RStudio, so no action is
 necessary.
 
 <figure>
-```{r rmarkdown-wizards, echo = FALSE, fig.show = "hold", fig.alt = "R Markdown wizard monsters creating a R Markdown document from a recipe. Art by Alliso Horst", out.width="100%"}
+```{r rmarkdown-wizards, echo = FALSE, fig.show = "hold", fig.alt = "R Markdown wizard monsters creating a R Markdown document from a recipe. Art by Allison Horst", out.width="100%"}
 knitr::include_graphics("../fig/rmarkdown_wizards.png")
 ```
 <figcaption>


### PR DESCRIPTION
The image captions are not currently showing up on the website with the Markdown syntax `![caption](filepath)`, so I have changed it to html syntax and added alt text.

I'm not really sure why the Markdown syntax isn't working, so I borrowed the html syntax from the 'Before we Start' episode.