### PR TITLE
Add info about nulls in dataset

### DIFF
--- a/_episodes_rmd/02-starting-with-data.Rmd
+++ b/_episodes_rmd/02-starting-with-data.Rmd
@@ -63,7 +63,7 @@ in other lessons in this workshop, see the
 [dataset description](http://www.datacarpentry.org/socialsci-workshop/data/).
 
 We will be using a subset of the cleaned version of the dataset that
-was produced through cleaning in OpenRefine (`data/SAFI_clean.csv`). Each row holds
+was produced through cleaning in OpenRefine (`data/SAFI_clean.csv`). In this dataset, the missing data is encoded as "NULL", each row holds
 information for a single interview respondent, and the columns
 represent:
 


### PR DESCRIPTION
Addresses issue #351 
The PR includes a line about how the missing data is encoded in the SAFI dataset