### PR TITLE
Fix error 404 on Contributing link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ You can also [reach us by email][contact].
 [github]: http://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
-[how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+[how-contribute]: https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://github.com/datacarpentry/r-socialsci/issues/
 [repo]: https://github.com/datacarpentry/r-socialsci
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry


### PR DESCRIPTION
The link for the  "How to Contribute to an Open Source Project on GitHub" article was broken, this PR fixes it.