### PR TITLE
Cheatsheet links

### DIFF
--- a/_episodes_rmd/00-intro.Rmd
+++ b/_episodes_rmd/00-intro.Rmd
@@ -320,7 +320,7 @@ selected text will be sent to the console and executed when you press
 <kbd>Ctrl</kbd> + <kbd>Enter</kbd>. If there is information in the console
 you do not need anymore, you can clear it with <kbd>Ctrl</kbd> + <kbd>L</kbd>.
 You can find other keyboard shortcuts in this
-[RStudio cheatsheet about the RStudio IDE](https://github.com/rstudio/cheatsheets/raw/master/rstudio-ide.pdf).
+[RStudio cheatsheet about the RStudio IDE](https://raw.githubusercontent.com/rstudio/cheatsheets/main/rstudio-ide.pdf).
 
 At some point in your analysis, you may want to check the content of a variable
 or the structure of an object without necessarily keeping a record of it in

--- a/_episodes_rmd/01-intro-to-r.Rmd
+++ b/_episodes_rmd/01-intro-to-r.Rmd
@@ -55,8 +55,7 @@ area_hectares <- 1.0
 the left. So, after executing `x <- 3`, the value of `x` is `3`. The arrow can
 be read as 3 **goes into** `x`.  For historical reasons, you can also use `=`
 for assignments, but not in every context. Because of the
-[slight](http://blog.revolutionanalytics.com/2008/12/use-equals-or-arrow-for-assignment.html)
-[differences](http://r.789695.n4.nabble.com/Is-there-any-difference-between-and-tp878594p878598.html)
+[slight differences](http://blog.revolutionanalytics.com/2008/12/use-equals-or-arrow-for-assignment.html)
 in syntax, it is good practice to always use `<-` for assignments. More 
 generally we prefer the `<-` syntax over `=` because it makes it clear what
 direction the assignment is operating (left assignment), and it increases the

--- a/_episodes_rmd/03-dplyr-tidyr.Rmd
+++ b/_episodes_rmd/03-dplyr-tidyr.Rmd
@@ -88,8 +88,8 @@ To easily access the documentation for a package within R or RStudio, use
 `help(package = "package_name")`.
 
 To learn more about **`dplyr`** and **`tidyr`** after the workshop, you may want
-to check out this [handy data transformation with **`dplyr`** cheatsheet](https://github.com/rstudio/cheatsheets/raw/master/data-transformation.pdf)
-and this [one about **`tidyr`**](https://github.com/rstudio/cheatsheets/raw/master/data-import.pdf).
+to check out this [handy data transformation with **`dplyr`** cheatsheet](https://raw.githubusercontent.com/rstudio/cheatsheets/main/data-transformation.pdf)
+and this [one about **`tidyr`**](https://raw.githubusercontent.com/rstudio/cheatsheets/main/tidyr.pdf).
 
 ## Learning **`dplyr`** and **`tidyr`**
 

--- a/_episodes_rmd/04-ggplot2.Rmd
+++ b/_episodes_rmd/04-ggplot2.Rmd
@@ -631,7 +631,7 @@ themes.
 ## Customization
 
 Take a look at the [**`ggplot2`** cheat
-sheet](https://github.com/rstudio/cheatsheets/blob/master/data-visualization-2.1.pdf),
+sheet](https://raw.githubusercontent.com/rstudio/cheatsheets/main/data-visualization.pdf),
 and think of ways you could improve the plot.
 
 Now, let's change names of axes to something more informative than 'village' and

--- a/_episodes_rmd/04-ggplot2.Rmd
+++ b/_episodes_rmd/04-ggplot2.Rmd
@@ -718,7 +718,7 @@ percent_items %>%
 >
 > With all of this information in hand, please take another five minutes to
 > either improve one of the plots generated in this exercise or create a
-> beautiful graph of your own. Use the RStudio [**`ggplot2`** cheat sheet](https://www.rstudio.com/wp-content/uploads/2016/11/ggplot2-cheatsheet-2.1.pdf)
+> beautiful graph of your own. Use the RStudio [**`ggplot2`** cheat sheet](https://raw.githubusercontent.com/rstudio/cheatsheets/main/data-visualization.pdf)
 > for inspiration. Here are some ideas:
 >
 > * See if you can make the bars white with black outline.


### PR DESCRIPTION
Replaced broken links to cheat sheets. Additionally, removed broken link to second resource on differences of arrow or equals assignment without replacement. Fixes #369.
