### PR TITLE
Include tidyverse dependencies for Ubuntu

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -96,7 +96,9 @@ installr::updateR(TRUE)
   rstudio-x.yy.zzz-amd64.deb` at the terminal).
 * Once it's installed, open RStudio to make sure it works and you don't get any
   error messages.
-
+* Before installing the `tidyverse` package, **Ubuntu** (and related) users may
+  need to install the following dependencies: `libcurl4-openssl-dev libssl-dev libxml2-dev`
+  (e.g. `sudo apt install libcurl4-openssl-dev libssl-dev libxml2-dev`).
 
 ### For everyone
 


### PR DESCRIPTION
As it is currently described, the Linux `tidyverse` setup may not work for Ubuntu users (and other distros based on Ubuntu). I included the code needed to install the dependencies for `tidyverse` (feel free to rearrange it, I wasn't sure where it would fit best).
