### PR TITLE
Update 03-dplyr-tidyr.Rmd

### DIFF
--- a/_episodes_rmd/03-dplyr-tidyr.Rmd
+++ b/_episodes_rmd/03-dplyr-tidyr.Rmd
@@ -693,7 +693,7 @@ To recreate our original dataframe, we will use the following:
 
 
 ```{r, purl = FALSE}
-interviews_wide %>%
+interviews_long <- interviews_wide %>%
   pivot_longer(cols = c("muddaub", "cement", "sunbricks", "burntbricks"),
                names_to = "respondent_wall_type",
                values_to = "wall_type_logical")

--- a/_episodes_rmd/03-dplyr-tidyr.Rmd
+++ b/_episodes_rmd/03-dplyr-tidyr.Rmd
@@ -693,10 +693,10 @@ To recreate our original dataframe, we will use the following:
 
 
 ```{r, purl = FALSE}
-interviews_long <- interviews_wide %>%
-    pivot_longer(cols = burntbricks:sunbricks,
-                 names_to = "respondent_wall_type",
-                 values_to = "wall_type_logical")
+interviews_wide %>%
+  pivot_longer(cols = c("muddaub", "cement", "sunbricks", "burntbricks"),
+               names_to = "respondent_wall_type",
+               values_to = "wall_type_logical")
 ```
 
 


### PR DESCRIPTION
<details>
<summary><strong>Instructions</strong></summary>
errors in the pivot_longer() section of r-socialsci/_episodes_rmd/03-dplyr-tidyr.Rmd #395
line 695 changed as: 
interviews_wide %>%
  pivot_longer(cols = c("muddaub", "cement", "sunbricks", "burntbricks"),
               names_to = "respondent_wall_type",
               values_to = "wall_type_logical")
</details>
