### PR TITLE
Update 04-ggplot2.Rmd

### DIFF
--- a/_episodes_rmd/04-ggplot2.Rmd
+++ b/_episodes_rmd/04-ggplot2.Rmd
@@ -215,7 +215,7 @@ opposed to lighter gray):
 ```{r adding-transparency, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = no_membrs, y = number_items)) +
-    geom_point(alpha = 0.5)
+    geom_point(alpha = 0.3)
 ```
 
 That only helped a little bit with the overplotting problem, so let's try option
@@ -244,7 +244,7 @@ between 0.1 and 0.4. Experiment with the values to see how your plot changes.
 ```{r adding-width-height, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = no_membrs, y = number_items)) +
-    geom_jitter(alpha = 0.5,
+    geom_jitter(alpha = 0.3,
                 width = 0.2,
                 height = 0.2)
 ```
@@ -255,7 +255,7 @@ a `color` argument inside the `geom_jitter()` function:
 ```{r adding-colors, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = no_membrs, y = number_items)) +
-    geom_jitter(alpha = 0.5,
+    geom_jitter(alpha = 0.3,
                 color = "blue",
                 width = 0.2,
                 height = 0.2)
@@ -278,7 +278,7 @@ of the observation:
 ```{r color-by-species, purl=FALSE}
 interviews_plotting %>%
     ggplot(aes(x = no_membrs, y = number_items)) +
-    geom_jitter(aes(color = village), alpha = 0.5, width = 0.2, height = 0.2)
+    geom_jitter(aes(color = village), alpha = 0.3, width = 0.2, height = 0.2)
 ```
 
 There appears to be a positive trend between number of household
@@ -315,7 +315,7 @@ this trend does not appear to be different by village.
 > > interviews_plotting %>%
 > >     ggplot(aes(x = village, y = rooms)) +
 > >     geom_jitter(aes(color = respondent_wall_type),
-> >		    alpha = 0.5,
+> >		    alpha = 0.3,
 > > 		    width = 0.2,
 > > 		    height = 0.2)
 > > ```
@@ -345,7 +345,7 @@ measurements and of their distribution:
 interviews_plotting %>%
     ggplot(aes(x = respondent_wall_type, y = rooms)) +
     geom_boxplot(alpha = 0) +
-    geom_jitter(alpha = 0.5,
+    geom_jitter(alpha = 0.3,
     		color = "tomato",
     		width = 0.2,
     		height = 0.2)


### PR DESCRIPTION
Modified the alpha value to 0.3 to make transparency more evident. Transparency with previous alpha value of 0.5 was barely noticeable on the screen.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
instructor.training@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
