### PR TITLE
add-citation-info-rmarkdown

### DIFF
--- a/episodes/06-rmarkdown.Rmd
+++ b/episodes/06-rmarkdown.Rmd
@@ -512,6 +512,27 @@ for more information.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+:::::::::::::::::::::::::::::::::::::::::  callout
+
+## Note: Inserting citations into an R Markdown file
+
+It is possible to insert citations into an R Markdown file using the
+editor toolbar. The editor toolbar includes commonly seen formatting
+buttons generally seen in text editors (e.g., bold and italic
+buttons). The toolbar is accessible by using the settings dropdown
+menu (next to the 'Knit' dropdown menu) to select 'Use Visual Editor',
+also accessible through the shortcut 'Crtl+Shift+F4'. From here,
+clicking 'Insert' allows 'Citation' to be selected (shortcut:
+'Crtl+Shift+F8'). For example, searching '10.1007/978-3-319-24277-4'
+in 'From DOI' and inserting will provide the citation for `ggplot2`
+[@wickham2016]. This will also save the citation(s) in
+'references.bib' in the current working directory. Visit the [R Studio
+website](https://rstudio.github.io/visual-markdown-editing/) for more
+information. Tip: obtaining citation information from relevant
+packages can be done by using `citation("package")`.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
 ## Resources
 
 - [Knitr in a knutshell tutorial](https://kbroman.org/knitr_knutshell)


### PR DESCRIPTION
Added brief info about how to cite in R markdown and how to get citation info from R packages.