### PR TITLE
Fix callout overlap

### DIFF
--- a/episodes/06-rmarkdown.Rmd
+++ b/episodes/06-rmarkdown.Rmd
@@ -238,14 +238,13 @@ call it 'setup'. Since we don't want this code or the output to show in our
 knitted HTML document, we add an `include = FALSE` option after the code chunk
 name (`{r setup, include = FALSE}`).
 
-<pre>
-&#96;&#96;&#96;{r setup, include = FALSE}
+````{verbatim, lang = "markdown"}
+```{r setup, include = FALSE}
 library(tidyverse)
 library(here)
 interviews <- read_csv(here("data/SAFI_clean.csv"), na = "NULL")
-&#96;&#96;&#96;
-</pre>
-
+```
+````
 :::::::::::::::::::::::::::::::::::::::::  callout
 
 ## Important Note!

--- a/episodes/06-rmarkdown.Rmd
+++ b/episodes/06-rmarkdown.Rmd
@@ -215,14 +215,14 @@ and <kbd>Cmd</kbd>\+<kbd>Option</kbd>\+<kbd>I</kbd> on Mac.
 
 The syntax of a code chunk is:
 
-<pre>
-&#96;&#96;&#96;{r chunk-name}
+````{verbatim, lang = "markdown"}
+```{r chunk-name}
 Here is where you place the R code that you want to run.
-&#96;&#96;&#96;
-</pre>
+```
+````
 
 An R Markdown document knows that this text is not part of the report from the
-`&#96;&#96;&#96` that begins and ends the chunk. It also knows that the code
+```` ``` ```` that begins and ends the chunk. It also knows that the code
 inside of the chunk is R code from the `r` inside of the curly braces (`{}`).
 After the `r` you can add a name for the code chunk . Naming a chunk is
 optional, but recommended. Each chunk name must be unique, and only contain
@@ -465,12 +465,12 @@ interviews_plotting %>%
 
 We can also create a caption with the chunk option `fig.cap`.
 
-<pre>
-&#96;&#96;&#96;{r chunk-name, fig.cap = "I made this plot while attending an
+````{verbatim, lang = "markdown"}
+```{r chunk-name, fig.cap = "I made this plot while attending an
 awesome Data Carpentries workshop where I learned a ton of cool stuff!"}
 Code for plot
-&#96;&#96;&#96;
-</pre>
+```
+````
 
 ...or, ideally, something more informative.
 


### PR DESCRIPTION
Resolves #460 by using verbatim tags as recommended by @zkamvar in https://github.com/carpentries/sandpaper/issues/456#issuecomment-1548370077

Thanks to @jlahne for reporting the issue and reporting back with the solution. I have added you both as co-authors on the commit that fixes the problem.