### PR TITLE
Correct instructor notes link and change callout to instructor type

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,12 +37,12 @@ everything *before* working through this lesson.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-::::::::::::::::::::::::::::::::::::::::::  prereq
+::::::::::::::::::::::::::::::::::::::::::  instructor
 
 ## For Instructors
 
 If you are teaching this lesson in a workshop, please see the
-[Instructor notes](guide/).
+[Instructor notes](https://datacarpentry.org/r-socialsci/instructor/instructor-notes.html)https://datacarpentry.org/r-socialsci/instructor/instructor-notes.html).
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
Replace broken link to instructor notes with complete link. This should probably be a relative link but I can't remember the correct format.

Additionally, change the callout to `instructor` instead of `prereq` so it appears on the instructor page but not the learner page.