### PR TITLE
Fix explanation of `NA` result from `separate_rows()` function

### DIFF
--- a/episodes/04-tidyr.Rmd
+++ b/episodes/04-tidyr.Rmd
@@ -324,13 +324,13 @@ other with "solar panel" in the `items_owned` column.
 separate_rows(items_owned, sep = ";") %>%
 ```
 
-You may notice that one of the columns is called `´NA´`. This is because some
-of the respondents did not own any of the items that was in the interviewer's
-list. We can use the `replace_na()` function to change these `NA` values to
-something more meaningful. The `replace_na()` function expects for you to give
-it a `list()` of columns that you would like to replace the `NA` values in,
-and the value that you would like to replace the `NA`s. This ends up looking
-like this:
+You may notice that the `items_owned` column contains `NA` values. 
+This is because some of the respondents did not own any of the items that was in
+the interviewer's list. We can use the `replace_na()` function to change these
+`NA` values to something more meaningful. The `replace_na()` function expects
+for you to give it a `list()` of columns that you would like to replace the `NA`
+values in, and the value that you would like to replace the `NA`s. This ends up
+looking like this:
 
 ```{r, eval=FALSE}
 replace_na(list(items_owned = "no_listed_items")) %>%


### PR DESCRIPTION
I noticed that the explanation of what the `separate_rows()` function does in the "Applying `pivot_wider()` to clean our data" section of the episode "Data Wrangling with tidyr" is not correct. It originally says that there is a column with the name `NA` after applying `separate_rows()`. However, what actually happens is that the column `items_owned` contains `NA` values. These are replaced with the following command `replace_na()`.

I fixed the explanation of what happens after `separate_rows()`. Please feel free to comment on/suggest an alternative phrasing.

#462 discusses to replace `separate_rows()` by `separate_longer_delim()`. The corrected explanation in this PR still hold for the preferred `separate_longer_delim()` function.
