### PR TITLE
Update slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/datacarpentry/r-socialsci.svg?branch=master)](https://travis-ci.com/github/datacarpentry/r-socialsci)
-[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
-[![Slack Status](https://img.shields.io/badge/Slack_Channel-dc--socsci--r-E01563.svg)](https://swcarpentry.slack.com/messages/C9X9JDTSR)
+[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://slack-invite.carpentries.org/)
+[![Slack Status](https://img.shields.io/badge/Slack_Channel-dc--socsci--r-E01563.svg)](https://carpentries.slack.com/messages/C9X9JDTSR)
 [![DOI](https://zenodo.org/badge/92420906.svg)](https://zenodo.org/badge/latestdoi/92420906)
 
 # r-socialsci


### PR DESCRIPTION
The Carpentries recently updated their Slack domain URL and invite app URL. This PR updates the links to match the new domains.
