### PR TITLE
fix 'unexpected symbol' error

### DIFF
--- a/episodes/06-rmarkdown.Rmd
+++ b/episodes/06-rmarkdown.Rmd
@@ -217,7 +217,7 @@ The syntax of a code chunk is:
 
 ````{verbatim, lang = "markdown"}
 ```{r chunk-name}
-Here is where you place the R code that you want to run.
+"Here is where you place the R code that you want to run."
 ```
 ````
 


### PR DESCRIPTION
During a local build with `sandpaper::build_lesson()` I get the following error:

```
ERROR 1: <text>:220:6: unexpected symbol
219: 
220: Here is
```

This is resolved by adding quotation marks around the text in the code chunk.