### PR TITLE
fix the summary table for mean items

### DIFF
--- a/episodes/04-tidyr.Rmd
+++ b/episodes/04-tidyr.Rmd
@@ -384,6 +384,7 @@ by village.
 
 ```{r, purl=FALSE}
 interviews_items_owned %>%
+    select(-no_listed_items) %>% 
     mutate(number_items = rowSums(select(., bicycle:car))) %>%
     group_by(village) %>%
     summarize(mean_items = mean(number_items))


### PR DESCRIPTION
While working on #470 I noticed that there was a mistake in the summary table in
https://github.com/datacarpentry/r-socialsci/blob/c479d9374cfe42903129240ce7eee878b85e6e6c/episodes/04-tidyr.Rmd#L386C1-L386C1

It was assumed that `no_listed_items` was at the end of the items variables and could be excluded by taking the mean of columns `bicycle:car`. It seems that it is located somewhere in between `bicycle` and `car`, so the mean, which was supposed to count all items except `no_listed_items`, is actually the mean including `no_listed_items`.

This adds the line `select(-no_listed_items)` to explicitly ensure that `no_listed_items` is not included in the mean.