### PR TITLE
Update 05-ggplot2.Rmd

### DIFF
--- a/episodes/05-ggplot2.Rmd
+++ b/episodes/05-ggplot2.Rmd
@@ -236,7 +236,9 @@ locations where there are overlapping points. Jittering introduces a little bit
 of randomness into the position of our points. You can think of this process as
 taking the overplotted graph and giving it a tiny shake. The points will move a
 little bit side-to-side and up-and-down, but their position from the original
-plot won't dramatically change.
+plot won't dramatically change. Note that this solution is suitable for plotting 
+integer figures, while for numeric figures with decimals, geom_jitter() becomes 
+inappropriate because it obscures the true value of the observation.
 
 We can jitter our points using the `geom_jitter()` function instead of the
 `geom_point()`  function, as seen below:


### PR DESCRIPTION
Added this comment:

Note that this solution is suitable for plotting 
integer figures, while for numeric figures with decimals, geom_jitter() becomes  inappropriate because it obscures the true value of the observation.

That addresses the issue: Problems with geom_jitter() for numeric columns #479

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
