### PR TITLE
Update 02-starting-with-data.Rmd

### DIFF
--- a/episodes/02-starting-with-data.Rmd
+++ b/episodes/02-starting-with-data.Rmd
@@ -539,10 +539,10 @@ plot(memb_assoc)
 ```
 
 Looking at the plot compared to the output of the vector, we can see that in
-addition to "no"s and "yes"s, there are some respondents for which the
+addition to "no"s and "yes"s, there are some respondents for whom the
 information about whether they were part of an irrigation association hasn't
-been recorded, and encoded as missing data. They do not appear on the plot.
-Let's encode them differently so they can counted and visualized in our plot.
+been recorded, and encoded as missing data. These respondents do not appear on the plot.
+Let's encode them differently so they can be counted and visualized in our plot.
 
 ```{r factor-plot-reorder, fig.alt="Bar plot of association membership, showing missing responses.", purl=TRUE}
 ## Let's recreate the vector from the data frame column "memb_assoc"


### PR DESCRIPTION
Fixed typos and improved clarity in section about Renaming Factors

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

Closes #495

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

Improved clarity by fixing typos in discussion of Renaming Factors
( The paragraph about respondents with missing data isn't clear. )
The lack of clarity is mainly caused by two typos (sentences are missing parts of verbs - "is" and "be")
The meaning is also somewhat muddied because we usually use "who" to refer to people (not "which")

_If any relevant discussions have taken place elsewhere, please provide links to these._

[https://github.com/datacarpentry/r-socialsci/issues/495](https://github.com/datacarpentry/r-socialsci/issues/495)
<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
