### PR TITLE
Make backticks visible

### DIFF
--- a/episodes/06-rmarkdown.Rmd
+++ b/episodes/06-rmarkdown.Rmd
@@ -143,7 +143,7 @@ and, if you're feeling bold (pun intended), you can also use a combination of
 asterisks and underscores, `**_really_**`, `**_really_**`.
 
 To create `code-type` font, surround the word with backticks,
-`code-type`.
+`` `code-type` ``.
 
 Now that we've learned a couple of things, it might be useful to implement them:
 


### PR DESCRIPTION
In the description on how to include code snippets in Markdown the backticks are not visible. 

To solve this issue I only found this syntax: 

`` `code` `` 

Unfortunately, this will add spaces at the beginning and end of the code snippet.