### PR TITLE
Update 04-tidyr.Rmd

### DIFF
--- a/episodes/04-tidyr.Rmd
+++ b/episodes/04-tidyr.Rmd
@@ -82,15 +82,7 @@ either variable as an identifier corresponding to the 131 interview records.
 ```{r, purl=FALSE}
 interviews %>% 
   select(key_ID) %>% 
-  distinct() %>% 
-  count()
-```
-
-```{r, purl=FALSE}
-interviews %>% 
-  select(instanceID) %>% 
-  distinct() %>% 
-  count()
+  n_distinct() 
 ```
 
 As seen in the code below, for each interview date in each village no

--- a/episodes/04-tidyr.Rmd
+++ b/episodes/04-tidyr.Rmd
@@ -82,7 +82,8 @@ either variable as an identifier corresponding to the 131 interview records.
 ```{r, purl=FALSE}
 interviews %>% 
   select(key_ID) %>% 
-  n_distinct() 
+  distinct() %>%
+  nrow()
 ```
 
 As seen in the code below, for each interview date in each village no


### PR DESCRIPTION
Removed example concerning distinct instanceID's to avoid repitition of showing the length of distinct ids. Changed from `distinct() %>% count() ` to `distinct() %>% nrow() ` for key_ID. Considering  `n_distinct() ` might be another valid and more efficient option. 


Closes #543  