### PR TITLE
Some issue 526 fixes

### DIFF
--- a/episodes/03-dplyr.Rmd
+++ b/episodes/03-dplyr.Rmd
@@ -76,7 +76,7 @@ To easily access the documentation for a package within R or RStudio, use
 `help(package = "package_name")`.
 
 To learn more about **`dplyr`** after the workshop, you may want to check out this
-[handy data transformation with **`dplyr`** cheatsheet](https://raw.githubusercontent.com/rstudio/cheatsheets/main/data-transformation.pdf).
+[handy data transformation with **`dplyr`** cheatsheet](https://github.com/rstudio/cheatsheets/blob/main/data-transformation.pdf).
 
 :::::::::::::::::::::::::::::::::::::::::  callout
 

--- a/episodes/04-tidyr.Rmd
+++ b/episodes/04-tidyr.Rmd
@@ -28,7 +28,7 @@ source("data/download_data.R")
 convert between different data formats (long vs. wide) for plotting and analysis.
 To learn more about **`tidyr`** after the workshop, you may want to check out this
 [handy data tidying with **`tidyr`**
-cheatsheet](https://raw.githubusercontent.com/rstudio/cheatsheets/main/tidyr.pdf).
+cheatsheet](https://github.com/rstudio/cheatsheets/blob/main/tidyr.pdf).
 
 To make sure everyone will use the same dataset for this lesson, we'll read
 again the SAFI dataset that we downloaded earlier.

--- a/episodes/05-ggplot2.Rmd
+++ b/episodes/05-ggplot2.Rmd
@@ -726,7 +726,7 @@ using each of those themes. Which do you like best?
 ## Customization
 
 Take a look at the [**`ggplot2`** cheat
-sheet](https://raw.githubusercontent.com/rstudio/cheatsheets/main/data-visualization.pdf),
+sheet](https://github.com/rstudio/cheatsheets/blob/main/data-visualization-2.1.pdf),
 and think of ways you could improve the plot.
 
 Now, let's change names of axes to something more informative than 'village' and
@@ -814,7 +814,7 @@ percent_items %>%
 
 With all of this information in hand, please take another five minutes to
 either improve one of the plots generated in this exercise or create a
-beautiful graph of your own. Use the RStudio [**`ggplot2`** cheat sheet](https://raw.githubusercontent.com/rstudio/cheatsheets/main/data-visualization.pdf)
+beautiful graph of your own. Use the RStudio [**`ggplot2`** cheat sheet](https://github.com/rstudio/cheatsheets/blob/main/data-visualization-2.1.pdf)
 for inspiration. Here are some ideas:
 
 - See if you can make the bars white with black outline.

--- a/episodes/06-rmarkdown.Rmd
+++ b/episodes/06-rmarkdown.Rmd
@@ -550,7 +550,6 @@ packages can be done by using `citation("package")`.
 - [Markdown tutorial](https://commonmark.org/help/tutorial/)
 - [R Markdown: The Definitive Guide](https://bookdown.org/yihui/rmarkdown/) (book by Rstudio team)
 - [Reproducible Reporting](https://www.rstudio.com/resources/webinars/reproducible-reporting/)
-- [The Ecosystem of R Markdown](https://www.rstudio.com/resources/webinars/the-ecosystem-of-r-markdown/)
 - [Introducing Bookdown](https://www.rstudio.com/resources/webinars/introducing-bookdown/)
 
 :::::::::::::::::::::::::::::::::::::::: keypoints


### PR DESCRIPTION
Addresses some issue 526 points

Links to cheatsheet changed to rstudio github page as opposed to direct pdf downloads (dplyr, tidyr, ggplot2, RMarkdown link in resources list was already a github link).

Have left tidyverse link in episode 4 as did not appear as link in edit screen, no links added to episodes 5-7.

One link removed from RMarkdown resource list 'The Ecosystem of R Markdown' (no obvious replacement found), all other links are working so not altered.
