### PR TITLE
Activate Matomo tracking

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -84,5 +84,5 @@ profiles:
 # This space below is where custom yaml items (e.g. pinning
 # sandpaper and varnish versions) should live
 
-
+analytics: carpentries
 url: 'https://datacarpentry.org/r-socialsci'


### PR DESCRIPTION
This enables tracking with The Carpenties' Matomo web analytics platform, which will help us monitor traffic to the lesson. This was activated for most of our other lessons in 2024 and I am honestly not sure why the r-socialsci lesson was missed -- sorry!