### PR TITLE
Fix instructor note headings for libxml2 stricter checks

### DIFF
--- a/episodes/01-intro-to-r.Rmd
+++ b/episodes/01-intro-to-r.Rmd
@@ -107,17 +107,18 @@ for issues in the styling of your code.
 :::::::::::::::::::::::::::::::::::::::::  callout
 
 :::: instructor
-### Note on `<-` vs `<` with negative numbers
 
-Learners sometimes type `x<-5` intending a logical test “is `x` less than `-5`?”.  
-In R, `x<-5` is parsed as an **assignment** because `<-` is a single token.  
+### Notes on negative numbers and assignment
+
+Learners sometimes type `x<-5` intending a logical test "is `x` less than `-5`?".
+In R, `x<-5` is parsed as an **assignment** because `<-` is a single token.
 
 To resolve this you can either encourage spacing around operators or parentheses to avoid ambiguity:
 
-- Logical test: `x < -5`   (note the space between "<" and the "-" negative)  
+- Logical test: `x < -5`   (note the space between "<" and the "-" negative)
 - Assignment:   `x <- 5`
 
-- Alternative for clarity: `x < (-5)` (explicit negative value)  
+- Alternative for clarity: `x < (-5)` (explicit negative value)
 
 ::::::::::::
 
@@ -661,7 +662,7 @@ As mentioned in the [functions and their arguments section](#functions-and-their
 However, there are several other ways that people often get help when they are stuck with their R code.
 
 * Search the internet: paste the last line of your error message or “R” and a short description of what you want to do into your favorite search engine and you will usually find several examples where other people have encountered the same problem and came looking for help.
-  * Stack Overflow can be particularly helpful for this: answers to questions are presented as a ranked thread ordered according to how useful other users found them to be. You can search using the `[r]` tag. 
+  * Stack Overflow can be particularly helpful for this: answers to questions are presented as a ranked thread ordered according to how useful other users found them to be. You can search using the `[r]` tag.
   * **Take care**: copying and pasting code written by somebody else is risky unless you understand exactly what it is doing!
 * Ask somebody “in the real world”. If you have a colleague or friend with more expertise in R than you have, show them the problem you are having and ask them for help.
 * Sometimes, the act of articulating your question can help you to identify what is going wrong. This is known as [“rubber duck debugging”](https://en.wikipedia.org/wiki/Rubber_duck_debugging) among programmers.
@@ -671,6 +672,7 @@ However, there are several other ways that people often get help when they are s
 ::::::::::::::::::::::::::::: instructor
 
 ### Choose how to teach this section
+
 The section on generative AI is intended to be concise but Instructors may choose to devote more time to the topic in a workshop.
 Depending on your own level of experience and comfort with talking about and using these tools, you could choose to do any of the following:
 
@@ -678,7 +680,7 @@ Depending on your own level of experience and comfort with talking about and usi
 * Demonstrate how you recommend that learners use generative AI.
 * Discuss the ethical concerns listed below, as well as others that you are aware of, to help learners make an informed choice about whether or not to use generative AI tools.
 
-This is a fast-moving technology. 
+This is a fast-moving technology.
 If you are preparing to teach this section and you feel it has become outdated, please open an issue on the lesson repository to let the Maintainers know and/or a pull request to suggest updates and improvements.
 
 ::::::::::::::::::::::::::::::::::::::::
@@ -690,7 +692,7 @@ However, the way this help is provided by the chatbot is different.
 Answers on Stack Overflow have (probably) been given by a human as a direct response to the question asked.
 But generative AI chatbots, which are based on advanced statistical models called Large Language Models (or LLMs), respond by generating the _most likely_ sequence of text that would follow the prompt they are given.
 
-While responses from generative AI tools can often be helpful, they are not always reliable. 
+While responses from generative AI tools can often be helpful, they are not always reliable.
 These tools sometimes generate plausible but incorrect or misleading information, so (just as with an answer found on the internet) it is essential to verify their accuracy.
 You need the knowledge and skills to be able to understand these responses, to judge whether or not they are accurate, and to fix any errors in the code it offers you.
 
@@ -698,16 +700,16 @@ In addition to asking for help, programmers can use generative AI tools to gener
 However, there are drawbacks that you should be aware of.
 
 The models used by these tools have been "trained" on very large volumes of data, much of it taken from the internet, and the responses they produce reflect that training data, and may recapitulate its inaccuracies or biases.
-The environmental costs (energy and water use) of LLMs are a lot higher than other technologies, both during development (known as training) and when an individual user uses one (also called inference). For more information see the [AI Environmental Impact Primer](https://huggingface.co/blog/sasha/ai-environment-primer) developed by researchers at HuggingFace, an AI hosting platform. 
+The environmental costs (energy and water use) of LLMs are a lot higher than other technologies, both during development (known as training) and when an individual user uses one (also called inference). For more information see the [AI Environmental Impact Primer](https://huggingface.co/blog/sasha/ai-environment-primer) developed by researchers at HuggingFace, an AI hosting platform.
 Concerns also exist about the way the data for this training was obtained, with questions raised about whether the people developing the LLMs had permission to use it.
 Other ethical concerns have also been raised, such as reports that workers were exploited during the training process.
 
 **We recommend that you avoid getting help from generative AI during the workshop** for several reasons:
 
 1. For most problems you will encounter at this stage, help and answers can be found among the first results returned by searching the internet.
-2. The foundational knowledge and skills you will learn in this lesson by writing and fixing your own programs  are essential to be able to evaluate the correctness and safety of any code you receive from online help or a generative AI chatbot. 
+2. The foundational knowledge and skills you will learn in this lesson by writing and fixing your own programs  are essential to be able to evaluate the correctness and safety of any code you receive from online help or a generative AI chatbot.
    If you choose to use these tools in the future, the expertise you gain from learning and practicing these fundamentals on your own will help you use them more effectively.
-3. As you start out with programming, the mistakes you make will be the kinds that have also been made -- and overcome! -- by everybody else who learned to program before you. 
+3. As you start out with programming, the mistakes you make will be the kinds that have also been made -- and overcome! -- by everybody else who learned to program before you.
   Since these mistakes and the questions you are likely to have at this stage are common, they are also better represented than other, more specialized problems and tasks in the data that was used to train generative AI tools.
   This means that a generative AI chatbot is _more likely to produce accurate responses_ to questions that novices ask, which could give you a false impression of how reliable they will be when you are ready to do things that are more advanced.
 

--- a/index.md
+++ b/index.md
@@ -42,13 +42,10 @@ everything *before* working through this lesson.
 
 ::::::::::::::::::::::::::::::::::::::::::  instructor
 
-## For Instructors
+### For Instructors
 
 If you are teaching this lesson in a workshop, please see the
 [Instructor notes](https://datacarpentry.org/r-socialsci/instructor/instructor-notes.html)
 for helpful tips.
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::::
-
-

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -62,9 +62,6 @@ This character can be created using:
 ## Other Resources
 
 If you encounter a problem during a workshop, feel free to contact the
-maintainers by email or [open an
-issue](https://github.com/datacarpentry/r-socialsci/issues/new).
+maintainers by email or [open an issue](https://github.com/datacarpentry/r-socialsci/issues/new).
 
 For a more in-depth coverage of topics of the workshops, you may want to read "[R for Data Science](http://r4ds.had.co.nz/)" by Hadley Wickham and Garrett Grolemund.
-
-

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -56,7 +56,7 @@ section on the homepage of the course website for package installation instructi
 This character can be created using:
 
 ```
-`alt` + `1`
+alt + 1
 ```
 
 ## Other Resources


### PR DESCRIPTION
It seems in a recent update to libxml2, backticks (or less-than/greater-than symbols) in headings break the XML parsing somehow. This PR provides a workaround to adjust the problematic heading in the intro-to-r episode `::: instructor` callout.

I can look at providing a proper fix in a subsequent sandpaper release.